### PR TITLE
Adding GHES support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The scripts also require a few [Ruby gems](https://guides.rubygems.org/what-is-a
 2. Install bundler with `gem install bundler` (if running on macOS, your machine should already have Ruby installed).
 3. In your terminal, run `bundle install` to install the dependencies.
 4. This will generate a new file, Gemfile.lock, which contains the specific versions of the gems that were installed. If you're coming from the Node.js world, this Gemfile.lock file is similar [to `the package-lock.json` file](https://docs.npmjs.com/cli/v9/configuring-npm/package-lock-json). 
+5. Finally, create the `log` directory with `mkdir log` to contain records of executing scripts
 
 ## Create your .env file 
 THis script requires a few environment variables to be set. You can do this by creating a `.env` file in the working directory. I've created a `.env.sample` file to get started. Rename this file to be `.env` file, which should contain the following variables:
@@ -29,6 +30,17 @@ Once you've finished editing these values, you should have a .env file in the wo
 GH_ORG=my-source-org
 GH_TARGET_ORG=my-target-org
 GH_TOKEN=ghp_1234abcd
+```
+
+For working GitHub Enterprise Server, you will need to set 2 additional environment variables based on your GHES deployment:
+- `GH_REST_URL=` URL and path for making REST API calls
+- `GH_GRAPHQL_URL=` URL and path for making GraphQL API calls
+
+For example:
+
+```
+GH_GRAPHQL_API=https://0785a2994314098ba.example.com/api/graphql
+GH_REST_API=https://0785a2994314098ba.example.com/api/v3
 ```
 
 # Migrating teams

--- a/create_teams.rb
+++ b/create_teams.rb
@@ -1,12 +1,25 @@
 require "debug"
 require "yaml"
 require "octokit"
-require "dotenv/load"
+require "dotenv"
+require "optparse"
+
+options = { :env_file => ".env" }
+
+OptionParser.new do |opts|
+    opts.banner = "Usage: create_teams.rb [options]"
+
+    opts.on("-eENV_FILE", "--env=ENV_FILE", "Path to .env file") do |env_file|
+        options[:env_file] = env_file
+    end
+end.parse!
+
+Dotenv.load(options[:env_file])
 
 class TeamStructure
 
     def initialize
-        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"])
+        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"], :api_endpoint => ENV.fetch('GH_REST_API', 'https://api.github.com'))
         @client.auto_paginate = true
         @failed_team_creation = {}
         @created_teams = []

--- a/create_teams.rb
+++ b/create_teams.rb
@@ -53,7 +53,7 @@ class TeamStructure
         timestamp = Time.now.strftime("%Y-%m-%d-%H-%M-%S")
         file_name = "logs/create_teams_log_#{timestamp}.txt"
         File.open("#{file_name}", "w") do |file|
-            puts "Writing logs to logs/get_teams_log_#{timestamp}.txt... 📝"
+            puts "Writing logs to #{file_name}... 📝"
             file.puts "- Created #{@created_teams.length} teams in #{ENV["GH_TARGET_ORG"]}"
             file.puts " "
             # If we had some failed team creations, write a log of those

--- a/get_teams.rb
+++ b/get_teams.rb
@@ -2,12 +2,25 @@ require "hashie"
 require "debug"
 require "yaml"
 require "octokit"
-require "dotenv/load"
 require "graphql/client"
 require "graphql/client/http"
+require "dotenv"
+require "optparse"
+
+options = { :env_file => ".env" }
+
+OptionParser.new do |opts|
+    opts.banner = "Usage: get_teams.rb [options]"
+
+    opts.on("-eENV_FILE", "--env=ENV_FILE", "Path to .env file") do |env_file|
+        options[:env_file] = env_file
+    end
+end.parse!
+
+Dotenv.load(options[:env_file])
 
 module GitHub
-    HTTP = GraphQL::Client::HTTP.new("https://api.github.com/graphql") do
+    HTTP = GraphQL::Client::HTTP.new(ENV.fetch('GH_GRAPHQL_API', 'https://api.github.com/graphql')) do
         def headers(context)
             {
                 "Authorization" => "Bearer #{ENV["GH_TOKEN"]}",
@@ -78,7 +91,7 @@ end
 class TeamStructure 
     
     def initialize 
-        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"])
+        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"], :api_endpoint => ENV.fetch('GH_REST_API', 'https://api.github.com'))
         @client.auto_paginate = true
         @teams = @client.org_teams(ENV["GH_ORG"])
         @hierarchy = []

--- a/get_teams.rb
+++ b/get_teams.rb
@@ -183,7 +183,7 @@ class TeamStructure
         timestamp = Time.now.strftime("%Y-%m-%d-%H-%M-%S")
         file_name = "logs/get_teams_log_#{timestamp}.txt"
         File.open("#{file_name}", "w") do |file|
-            puts "Writing logs to logs/get_teams_log_#{timestamp}.txt... 📝"
+            puts "Writing logs to #{file_name}... 📝"
             file.puts "- Initial team members count in #{ENV["GH_ORG"]}: #{@team_count}"
             file.puts "- Successfully parsed #{parsed_team_count} teams within #{ENV["GH_ORG"]}"
             file.puts "------"

--- a/invite_members.rb
+++ b/invite_members.rb
@@ -1,13 +1,25 @@
-require "octokit"
 require "dotenv/load"
 require "debug"
 require "yaml"
+require "optparse"
+
+options = { :env_file => ".env" }
+
+OptionParser.new do |opts|
+    opts.banner = "Usage: invite_members.rb [options]"
+
+    opts.on("-eENV_FILE", "--env=ENV_FILE", "Path to .env file") do |env_file|
+        options[:env_file] = env_file
+    end
+end.parse!
+
+Dotenv.load(options[:env_file])
 
 
 class InviteMembers
 
     def initialize
-        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"])
+        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"], :api_endpoint => ENV.fetch('GH_REST_API', 'https://api.github.com'))
         @client.auto_paginate = true
         @hierarchy = YAML.load_file("teams.yml")
         @initial_org_members_count = @client.org_members(ENV["GH_ORG"]).count

--- a/invite_members.rb
+++ b/invite_members.rb
@@ -94,7 +94,7 @@ class InviteMembers
         timestamp = Time.now.strftime("%Y-%m-%d-%H-%M-%S")
         file_name = "logs/invite_members_log_#{timestamp}.txt"
         File.open("#{file_name}", "w") do |file|
-            puts "📝 Writing logs to invite_members_log_#{timestamp}.txt"
+            puts "📝 Writing logs to #{file_name}"
             file.puts "- Current org members count in #{ENV["GH_ORG"]}: #{@initial_org_members_count}"
             file.puts "- Invited #{@invited_members.count} members to #{ENV["GH_TARGET_ORG"]}:"
             @invited_members.each do |member|

--- a/transfer_repos.rb
+++ b/transfer_repos.rb
@@ -1,15 +1,27 @@
 require "octokit"
-require "dotenv/load"
 require "debug"
 require "yaml"
 require "pp"
 require "hashie"
+require "optparse"
+
+options = { :env_file => ".env" }
+
+OptionParser.new do |opts|
+    opts.banner = "Usage: transfer_repos.rb [options]"
+
+    opts.on("-eENV_FILE", "--env=ENV_FILE", "Path to .env file") do |env_file|
+        options[:env_file] = env_file
+    end
+end.parse!
+
+Dotenv.load(options[:env_file])
 
 class TransferRepos
 
     # Initiatlize with Octokit and the teams.yml file generate from create_teams.rb
     def initialize
-        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"])
+        @client = Octokit::Client.new(:access_token => ENV["GH_TOKEN"], :api_endpoint => ENV.fetch('GH_REST_API', 'https://api.github.com'))
         @client.auto_paginate = true
         @hierarchy = YAML.load_file("teams.yml")
         @hierarchy.extend Hashie::Extensions::DeepFind


### PR DESCRIPTION
# Overview

This pull request adds several enhancements for expanded use cases:

1. GHES support

   For GitHub customers needing to export and import teams across or outside of GHES environments, this pull request includes additional environment variables for overriding the URLs used for REST and GraphQL APIs.

1. Configurable `.env` support

   For GitHub customers needing to export and import teams across enterprise boundaries, it is necessary to work with wholly different API end points, organizations, and tokens.  This pull request expands the script with minimal option parsing to allow overriding of the default `.env` file for configuration information needed.

1. Captures setup note around `logs` directory
1. Fixes minor issue with progress output around log filenames

## Testing performed

1. Created `team-transfer-target` GHES organization

   <img width="1904" alt="Screenshot 2023-06-16 at 2 59 24 PM" src="https://github.com/apdarr/team-transfer/assets/2089743/4213c40f-ca42-40c4-a063-604f3c95f15a">

1. Setup `.env` for exporting teams from `tinyfists` GHEC organization

   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ cat .env
   GH_ORG=tinyfists
   GH_TARGET_ORG=
   GH_TOKEN=ghx_xxxxxxxxxxxxxx
   ADMIN_TO_DELETE=
   ```

1. Export teams from `tinyfists` GHEC organization

   <img width="1904" alt="Screenshot 2023-06-16 at 2 59 49 PM" src="https://github.com/apdarr/team-transfer/assets/2089743/a9e556ed-7906-472a-92fc-9588f42f18c1">

   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ ruby get_teams.rb 
   To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
   Fetching team hierarchy... ⚽️
   Writing team hierarchy to file... 📝
   Writing logs to logs/get_teams_log_2023-06-16-15-01-02.txt... 📝
   
   andyfeller/team-transfer ‹ghes-support*›$ cat logs/get_teams_log_2023-06-16-15-01-02.txt 
   - Initial team members count in tinyfists: 15
   - Successfully parsed 15 teams within tinyfists
   ------
   
   andyfeller/team-transfer ‹ghes-support*›$ cat teams.yml 
   ---
   - :team_name: admin
     :team_id: 6450759
     :parent:
     :members:
     - polivebranch
     :maintainers:
     - andyfeller
     :children: []
   - :team_name: away
     :team_id: 5177363
     :parent:
     :members:
     - evgenyrahman
     - apdarr
     :maintainers:
     - andyfeller
     :children:
     - :team_name: mostly-away
       :team_id: 5836500
       :parent: away
       :members:
       - apdarr
       :maintainers: []
       :children: []
     - :team_name: partly-away
       :team_id: 5836498
       :parent: away
       :members:
       - evgenyrahman
       :maintainers: []
       :children: []
   - :team_name: lgtm
     :team_id: 5814790
     :parent:
     :members:
     - bval
     - evgenyrahman
     - jefeish
     - garnertb
     - apdarr
     - BrytBoy
     - kevfoste
     - vila89
     - decyjphr
     - enyil
     - polivebranch
     - katiem0
     :maintainers:
     - andyfeller
     :children:
     - :team_name: lgtm-reviewers
       :team_id: 6111085
       :parent: lgtm
       :members:
       - evgenyrahman
       :maintainers:
       - andyfeller
       :children: []
   - :team_name: lgtm-sensitive
     :team_id: 6123331
     :parent:
     :members: []
     :maintainers:
     - andyfeller
     :children:
     - :team_name: lgtm-sensitive-reviewers
       :team_id: 6123335
       :parent: lgtm-sensitive
       :members: []
       :maintainers:
       - andyfeller
       :children: []
   - :team_name: monks
     :team_id: 5199086
     :parent:
     :members: []
     :maintainers:
     - andyfeller
     :children: []
   - :team_name: omni-reviewers
     :team_id: 5199367
     :parent:
     :members: []
     :maintainers:
     - andyfeller
     :children:
     - :team_name: reviewers
       :team_id: 5199369
       :parent: omni-reviewers
       :members:
       - evgenyrahman
       :maintainers:
       - andyfeller
       :children: []
   - :team_name: ps-delivery-engineers
     :team_id: 5263239
     :parent:
     :members:
     - evgenyrahman
     - jefeish
     - apdarr
     - JaredEgolf
     - ssulei7
     - decyjphr
     - katiem0
     :maintainers:
     - andyfeller
     :children: []
   - :team_name: pull-perms
     :team_id: 5836501
     :parent:
     :members:
     - apdarr
     :maintainers: []
     :children: []
   - :team_name: readers
     :team_id: 5836499
     :parent:
     :members:
     - evgenyrahman
     :maintainers: []
     :children: []
   - :team_name: under_scores
     :team_id: 6379627
     :parent:
     :members: []
     :maintainers:
     - andyfeller
     :children: []
   ```

1. Setup `.env-gheboot` for importing teams into `team-transfer-target` GHES organization

   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ cat .env-gheboot 
   GH_GRAPHQL_API=https://andyfeller-0785a2994314098ba.ghe-test.com/api/graphql
   GH_REST_API=https://andyfeller-0785a2994314098ba.ghe-test.com/api/v3
   GH_ORG=team-transfer-target
   GH_TARGET_ORG=team-transfer-target
   GH_TOKEN=ghx_xxxxxxxxxxxxxx
   ADMIN_TO_DELETE=
   ```

1. Import teams into `team-transfer-target` GHES organization

   <img width="1904" alt="Screenshot 2023-06-16 at 3 02 26 PM" src="https://github.com/apdarr/team-transfer/assets/2089743/a93a746d-94d4-4136-a229-e62129665e30">

   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ ruby create_teams.rb -e .env-gheboot 
   To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
   Creating teams in team-transfer-target... 🏗
   Writing logs to logs/create_teams_log_2023-06-16-15-02-04.txt... 📝

   andyfeller/team-transfer ‹ghes-support*›$ cat logs/create_teams_log_2023-06-16-15-02-04.txt 
   - Created 15 teams in team-transfer-target
   ```

1. Delete `teams.yml` from previous export prior to exporting teams from `team-transfer-target` GHES organization

   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ rm teams.yml 
   ```

1. Export teams from `team-transfer-target` GHES organization
   
   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ ruby get_teams.rb -e .env-gheboot
   To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
   Fetching team hierarchy... ⚽️
   Writing team hierarchy to file... 📝
   Writing logs to logs/get_teams_log_2023-06-16-15-13-09.txt... 📝
   
   andyfeller/team-transfer ‹ghes-support*›$ cat logs/get_teams_log_2023-06-16-15-13-09.txt 
   - Initial team members count in team-transfer-target: 15
   - Successfully parsed 15 teams within team-transfer-target
   ------
   
   andyfeller/team-transfer ‹ghes-support*›$ cat teams.yml 
   ---
   - :team_name: admin
     :team_id: 19
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children: []
   - :team_name: away
     :team_id: 20
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children:
     - :team_name: mostly-away
       :team_id: 21
       :parent: away
       :members: []
       :maintainers:
       - ghe-admin
       :children: []
     - :team_name: partly-away
       :team_id: 22
       :parent: away
       :members: []
       :maintainers:
       - ghe-admin
       :children: []
   - :team_name: lgtm
     :team_id: 23
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children:
     - :team_name: lgtm-reviewers
       :team_id: 24
       :parent: lgtm
       :members: []
       :maintainers:
       - ghe-admin
       :children: []
   - :team_name: lgtm-sensitive
     :team_id: 25
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children:
     - :team_name: lgtm-sensitive-reviewers
       :team_id: 26
       :parent: lgtm-sensitive
       :members: []
       :maintainers:
       - ghe-admin
       :children: []
   - :team_name: monks
     :team_id: 27
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children: []
   - :team_name: omni-reviewers
     :team_id: 28
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children:
     - :team_name: reviewers
       :team_id: 29
       :parent: omni-reviewers
       :members: []
       :maintainers:
       - ghe-admin
       :children: []
   - :team_name: ps-delivery-engineers
     :team_id: 30
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children: []
   - :team_name: pull-perms
     :team_id: 31
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children: []
   - :team_name: readers
     :team_id: 32
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children: []
   - :team_name: under_scores
     :team_id: 33
     :parent:
     :members: []
     :maintainers:
     - ghe-admin
     :children: []
   ```

1. Setup `.env-andyfeller-volcano` for importing teams into `andyfeller-volcano` GHEC EMU organization

   <img width="1904" alt="Screenshot 2023-06-16 at 3 20 15 PM" src="https://github.com/apdarr/team-transfer/assets/2089743/b8a1af34-2b42-4ce5-af4f-434a0b216cb9">
   
   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ cat .env-andyfeller-volcano 
   GH_ORG=andyfeller-volcano
   GH_TARGET_ORG=andyfeller-volcano
   GH_TOKEN=ghx_xxxxxxxx
   ADMIN_TO_DELETE=
   ```

1. Import teams into `andyfeller-volcano` GHEC EMU organization

   <img width="1904" alt="Screenshot 2023-06-16 at 3 21 54 PM" src="https://github.com/apdarr/team-transfer/assets/2089743/53421afb-d94a-4d40-a05a-7ce3c5c87914">

   ```shell
   andyfeller/team-transfer ‹ghes-support*›$ ruby create_teams.rb -e .env-andyfeller-volcano 
   To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
   Creating teams in andyfeller-volcano... 🏗
   Writing logs to logs/create_teams_log_2023-06-16-15-21-05.txt... 📝
   
   andyfeller/team-transfer ‹ghes-support*›$ cat logs/create_teams_log_2023-06-16-15-21-05.txt 
   - Created 15 teams in andyfeller-volcano
   ```
